### PR TITLE
Add runtime log level flag and MCP trace logging

### DIFF
--- a/src-tauri/src/core/mcp/commands.rs
+++ b/src-tauri/src/core/mcp/commands.rs
@@ -1,8 +1,8 @@
 use rmcp::model::{CallToolRequestParam, CallToolResult};
 use serde_json::{Map, Value};
 use tauri::{AppHandle, Emitter, Runtime, State};
-use tokio::time::timeout;
 use tokio::sync::oneshot;
+use tokio::time::timeout;
 
 use super::{
     constants::{DEFAULT_MCP_CONFIG, MCP_TOOL_CALL_TIMEOUT},
@@ -200,31 +200,63 @@ pub async fn call_tool(
 ) -> Result<CallToolResult, String> {
     // Set up cancellation if token is provided
     let (cancel_tx, cancel_rx) = oneshot::channel::<()>();
-    
+
     if let Some(token) = &cancellation_token {
         let mut cancellations = state.tool_call_cancellations.lock().await;
         cancellations.insert(token.clone(), cancel_tx);
+        log::debug!(
+            "Registered cancellation token '{}' for tool '{}'",
+            token,
+            tool_name
+        );
     }
 
     let servers = state.mcp_servers.lock().await;
 
     // Iterate through servers and find the first one that contains the tool
-    for (_, service) in servers.iter() {
+    for (server_name, service) in servers.iter() {
+        log::trace!(
+            "Checking MCP server '{}' for tool '{}'",
+            server_name,
+            tool_name
+        );
+
         let tools = match service.list_all_tools().await {
             Ok(tools) => tools,
-            Err(_) => continue, // Skip this server if we can't list tools
+            Err(err) => {
+                log::warn!("Failed to list tools for server '{}': {}", server_name, err);
+                continue; // Skip this server if we can't list tools
+            }
         };
+
+        let available_tools: Vec<String> = tools.iter().map(|t| t.name.to_string()).collect();
+        log::trace!(
+            "Server '{}' exposes tools: {:?}",
+            server_name,
+            available_tools
+        );
 
         if !tools.iter().any(|t| t.name == tool_name) {
             continue; // Tool not found in this server, try next
         }
 
-        println!("Found tool {} in server", tool_name);
+        log::debug!(
+            "Dispatching tool '{}' on MCP server '{}'",
+            tool_name,
+            server_name
+        );
 
         // Call the tool with timeout and cancellation support
+        let request_arguments = arguments.clone();
+        if let Some(args) = request_arguments.as_ref() {
+            log::trace!("Tool '{}' invocation arguments: {:?}", tool_name, args);
+        } else {
+            log::trace!("Tool '{}' invoked without arguments", tool_name);
+        }
+
         let tool_call = service.call_tool(CallToolRequestParam {
             name: tool_name.clone().into(),
-            arguments,
+            arguments: request_arguments,
         });
 
         // Race between timeout, tool call, and cancellation
@@ -232,24 +264,43 @@ pub async fn call_tool(
             tokio::select! {
                 result = timeout(MCP_TOOL_CALL_TIMEOUT, tool_call) => {
                     match result {
-                        Ok(call_result) => call_result.map_err(|e| e.to_string()),
+                        Ok(call_result) => call_result.map_err(|e| {
+                            format!(
+                                "Tool call '{}' on server '{}' failed: {}",
+                                tool_name,
+                                server_name,
+                                e
+                            )
+                        }),
                         Err(_) => Err(format!(
-                            "Tool call '{}' timed out after {} seconds",
+                            "Tool call '{}' on server '{}' timed out after {} seconds",
                             tool_name,
+                            server_name,
                             MCP_TOOL_CALL_TIMEOUT.as_secs()
                         )),
                     }
                 }
                 _ = cancel_rx => {
+                    log::warn!(
+                        "Tool '{}' on server '{}' was cancelled via token",
+                        tool_name,
+                        server_name
+                    );
                     Err(format!("Tool call '{}' was cancelled", tool_name))
                 }
             }
         } else {
             match timeout(MCP_TOOL_CALL_TIMEOUT, tool_call).await {
-                Ok(call_result) => call_result.map_err(|e| e.to_string()),
+                Ok(call_result) => call_result.map_err(|e| {
+                    format!(
+                        "Tool call '{}' on server '{}' failed: {}",
+                        tool_name, server_name, e
+                    )
+                }),
                 Err(_) => Err(format!(
-                    "Tool call '{}' timed out after {} seconds",
+                    "Tool call '{}' on server '{}' timed out after {} seconds",
                     tool_name,
+                    server_name,
                     MCP_TOOL_CALL_TIMEOUT.as_secs()
                 )),
             }
@@ -259,11 +310,31 @@ pub async fn call_tool(
         if let Some(token) = &cancellation_token {
             let mut cancellations = state.tool_call_cancellations.lock().await;
             cancellations.remove(token);
+            log::trace!(
+                "Removed cancellation token '{}' for tool '{}'",
+                token,
+                tool_name
+            );
+        }
+
+        match &result {
+            Ok(success) => {
+                log::trace!(
+                    "Tool '{}' on server '{}' completed with response: {:?}",
+                    tool_name,
+                    server_name,
+                    success
+                );
+            }
+            Err(err) => {
+                log::error!("{err}");
+            }
         }
 
         return result;
     }
 
+    log::error!("Tool '{}' not found on any connected MCP server", tool_name);
     Err(format!("Tool {} not found", tool_name))
 }
 
@@ -281,14 +352,21 @@ pub async fn cancel_tool_call(
     cancellation_token: String,
 ) -> Result<(), String> {
     let mut cancellations = state.tool_call_cancellations.lock().await;
-    
+
     if let Some(cancel_tx) = cancellations.remove(&cancellation_token) {
         // Send cancellation signal - ignore if receiver is already dropped
         let _ = cancel_tx.send(());
-        println!("Tool call with token {} cancelled", cancellation_token);
+        log::info!("Cancellation requested for token '{}'", cancellation_token);
         Ok(())
     } else {
-        Err(format!("Cancellation token {} not found", cancellation_token))
+        log::warn!(
+            "Cancellation token '{}' not found when attempting to cancel tool call",
+            cancellation_token
+        );
+        Err(format!(
+            "Cancellation token {} not found",
+            cancellation_token
+        ))
     }
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,9 +7,10 @@ use core::{
     state::AppState,
 };
 use jan_utils::generate_app_token;
-use std::{collections::HashMap, sync::Arc};
-use tauri_plugin_deep_link::DeepLinkExt;
+use log::LevelFilter;
+use std::{collections::HashMap, env, sync::Arc};
 use tauri::{Emitter, Manager, RunEvent};
+use tauri_plugin_deep_link::DeepLinkExt;
 use tauri_plugin_llamacpp::cleanup_llama_processes;
 use tokio::sync::Mutex;
 
@@ -17,6 +18,7 @@ use crate::core::setup::setup_tray;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    let (log_level, log_level_source) = resolve_log_level_from_args();
     let mut builder = tauri::Builder::default();
     #[cfg(desktop)]
     {
@@ -135,10 +137,10 @@ pub fn run() {
             }
             _ => {}
         })
-        .setup(|app| {
+        .setup(move |app| {
             app.handle().plugin(
                 tauri_plugin_log::Builder::default()
-                    .level(log::LevelFilter::Debug)
+                    .level(log_level)
                     .targets([
                         tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::Stdout),
                         tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::Webview),
@@ -149,6 +151,14 @@ pub fn run() {
                     ])
                     .build(),
             )?;
+            match log_level_source {
+                Some(source) => {
+                    log::info!("Initialized logging at level {:?} via {source}", log_level);
+                }
+                None => {
+                    log::info!("Initialized logging at default level {:?}", log_level);
+                }
+            }
             app.handle()
                 .plugin(tauri_plugin_updater::Builder::new().build())?;
             // Install extensions
@@ -192,4 +202,58 @@ pub fn run() {
         }
         _ => {}
     });
+}
+
+fn resolve_log_level_from_args() -> (LevelFilter, Option<String>) {
+    let mut args = env::args().skip(1).peekable();
+    while let Some(arg) = args.next() {
+        if let Some(value) = arg.strip_prefix("--log-level=") {
+            return match parse_log_level(value) {
+                Ok(level) => (level, Some("--log-level".to_string())),
+                Err(err) => {
+                    eprintln!("{err}");
+                    (
+                        LevelFilter::Debug,
+                        Some("--log-level (invalid value)".to_string()),
+                    )
+                }
+            };
+        }
+
+        if arg == "--log-level" {
+            if let Some(value) = args.next() {
+                return match parse_log_level(&value) {
+                    Ok(level) => (level, Some("--log-level".to_string())),
+                    Err(err) => {
+                        eprintln!("{err}");
+                        (
+                            LevelFilter::Debug,
+                            Some("--log-level (invalid value)".to_string()),
+                        )
+                    }
+                };
+            } else {
+                eprintln!(
+                    "--log-level flag requires a value (error, warn, info, debug, trace, off)"
+                );
+                return (LevelFilter::Debug, Some("--log-level".to_string()));
+            }
+        }
+    }
+
+    (LevelFilter::Debug, None)
+}
+
+fn parse_log_level(value: &str) -> Result<LevelFilter, String> {
+    match value.to_ascii_lowercase().as_str() {
+        "error" => Ok(LevelFilter::Error),
+        "warn" | "warning" => Ok(LevelFilter::Warn),
+        "info" => Ok(LevelFilter::Info),
+        "debug" => Ok(LevelFilter::Debug),
+        "trace" => Ok(LevelFilter::Trace),
+        "off" => Ok(LevelFilter::Off),
+        other => Err(format!(
+            "Unrecognized log level '{other}'. Expected one of: error, warn, info, debug, trace, off"
+        )),
+    }
 }


### PR DESCRIPTION
## Summary
- add a `--log-level` command-line flag that lets the desktop app raise or lower the tauri log filter while defaulting to the previous Debug behaviour
- surface the chosen filter level during setup so testers can confirm their requested verbosity
- expand MCP tooling diagnostics to trace server discovery, request payloads, responses, cancellations, and error cases

## Testing
- `cargo fmt --manifest-path src-tauri/Cargo.toml`
- `cargo check --manifest-path src-tauri/Cargo.toml` *(fails: missing system dependency glib-2.0 for glib-sys build script)*

------
https://chatgpt.com/codex/tasks/task_e_68d1790430b483279b327b1243d9dd18